### PR TITLE
[METADATA UPDATE] Global metadata changes - merge to Live

### DIFF
--- a/MPI/docfx.json
+++ b/MPI/docfx.json
@@ -44,6 +44,7 @@
 
                                         ],
                   "globalMetadata":  {
+                           "ms.technology": "microsoft-mpi",
                                          "breadcrumb_path":  "/message-passing-interface/breadcrumb/toc.json",
                                          "extendBreadcrumb":  true,
                                          "feedback_system":  "None",
@@ -51,7 +52,7 @@
                                          "ms.topic":  "conceptual",
                                          "author":  "dlepow",
                                          "ms.author":  "dlepow",
-                                         "ms.prod":  "windows-server-dev",
+                                         "ms.prod":  "windows",
                                          "contributors_to_exclude": ["nivnar"],
                                          "titleSuffix": "Message Passing Interface"
                                      },


### PR DESCRIPTION
Fixing[#607428 Remove ms.prod value windows-server-dev](https://dev.azure.com/ceapex/Content%20Learning%20Content%20Architecture/_workitems/edit/607428)

Remove ms.prod = windows-server-dev from all content 
Replace with ms.prod = windows and ms.technology = microsoft-mpi. 
