### PR TITLE
Update docfx.json for all topics to have ms.topic=reference

### DIFF
--- a/MPI/docfx.json
+++ b/MPI/docfx.json
@@ -49,7 +49,7 @@
                                          "extendBreadcrumb":  true,
                                          "feedback_system":  "Standard",
                                          "ROBOTS":  "INDEX,FOLLOW",
-                                         "ms.topic":  "conceptual",
+                                         "ms.topic":  "reference",
                                          "author":  "AnnaDaly",
                                          "ms.author":  "annalabu",
                                          "ms.prod":  "windows",


### PR DESCRIPTION
Currently the articles in this repository all have ms.topic=conceptual, but the articles appear to be hand written API reference. As a result, it should be ms.topic=reference. I have changed the docfx.json file so that this is corrected. Please review.